### PR TITLE
Fix timeout on CircleCI caused by git diff

### DIFF
--- a/bin/update-yarn-lock-file
+++ b/bin/update-yarn-lock-file
@@ -29,7 +29,7 @@ git config push.default simple
 yarn upgrade
 
 # Output the diff to CI
-git diff
+git --no-pager diff
 
 # Commit and push yarn.lock file
 git add yarn.lock


### PR DESCRIPTION
Thanks for a great tool!

When running this script on CircleCI, it often ended with a timeout since the `git diff` command prompts for user input if the diff is more than one page long. This PR disables the paging and thus eliminates the timeout, resulting in a successful job.

I did not manage to run the tests, see #1